### PR TITLE
Troubleshoot Vite build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Thumbs.db
 # Hardhat 或 Foundry 等工具產生的快取和 artifact 檔案
 artifacts/
 cache/
+!src/cache/
 coverage/
 coverage.json
 

--- a/src/cache/cacheStrategies.ts
+++ b/src/cache/cacheStrategies.ts
@@ -1,0 +1,77 @@
+// cache/cacheStrategies.ts
+
+interface CacheMetricsData {
+    hits: number;
+    misses: number;
+    totalRequests: number;
+    hitRate: number;
+    lastUpdated: number;
+}
+
+class CacheMetricsManager {
+    private metrics: CacheMetricsData = {
+        hits: 0,
+        misses: 0,
+        totalRequests: 0,
+        hitRate: 0,
+        lastUpdated: Date.now()
+    };
+
+    recordHit(): void {
+        this.metrics.hits++;
+        this.updateMetrics();
+    }
+
+    recordMiss(): void {
+        this.metrics.misses++;
+        this.updateMetrics();
+    }
+
+    private updateMetrics(): void {
+        this.metrics.totalRequests = this.metrics.hits + this.metrics.misses;
+        this.metrics.hitRate = this.metrics.totalRequests > 0 
+            ? (this.metrics.hits / this.metrics.totalRequests) * 100 
+            : 0;
+        this.metrics.lastUpdated = Date.now();
+    }
+
+    getMetrics(): CacheMetricsData {
+        return { ...this.metrics };
+    }
+
+    reset(): void {
+        this.metrics = {
+            hits: 0,
+            misses: 0,
+            totalRequests: 0,
+            hitRate: 0,
+            lastUpdated: Date.now()
+        };
+    }
+
+    logMetrics(): void {
+        const { hits, misses, totalRequests, hitRate } = this.metrics;
+        console.log(`Cache Metrics: ${hits} hits, ${misses} misses, ${totalRequests} total requests, ${hitRate.toFixed(2)}% hit rate`);
+    }
+}
+
+export const CacheMetrics = new CacheMetricsManager();
+
+// Cache strategies for different scenarios
+export enum CacheStrategy {
+    PERMANENT = 'permanent',
+    TTL = 'ttl',
+    LRU = 'lru'
+}
+
+export interface CacheOptions {
+    strategy: CacheStrategy;
+    ttl?: number; // Time to live in milliseconds
+    maxSize?: number; // Maximum cache size for LRU
+}
+
+export const defaultCacheOptions: CacheOptions = {
+    strategy: CacheStrategy.PERMANENT,
+    ttl: 24 * 60 * 60 * 1000, // 24 hours
+    maxSize: 1000
+};

--- a/src/cache/nftMetadataCache.ts
+++ b/src/cache/nftMetadataCache.ts
@@ -1,0 +1,152 @@
+// cache/nftMetadataCache.ts
+import type { BaseNft } from '../types/nft';
+
+interface CachedMetadata {
+    tokenId: string;
+    contractAddress: string;
+    metadata: Omit<BaseNft, 'id' | 'contractAddress' | 'type'>;
+    timestamp: number;
+}
+
+class NFTMetadataCache {
+    private dbName = 'nft-metadata-cache';
+    private storeName = 'metadata';
+    private version = 1;
+    private db: IDBDatabase | null = null;
+
+    async init(): Promise<void> {
+        if (this.db) return;
+
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName, this.version);
+
+            request.onerror = () => reject(request.error);
+            request.onsuccess = () => {
+                this.db = request.result;
+                resolve();
+            };
+
+            request.onupgradeneeded = (event) => {
+                const db = (event.target as IDBOpenDBRequest).result;
+                if (!db.objectStoreNames.contains(this.storeName)) {
+                    const store = db.createObjectStore(this.storeName, { keyPath: 'cacheKey' });
+                    store.createIndex('tokenId', 'tokenId', { unique: false });
+                    store.createIndex('contractAddress', 'contractAddress', { unique: false });
+                    store.createIndex('timestamp', 'timestamp', { unique: false });
+                }
+            };
+        });
+    }
+
+    private getCacheKey(tokenId: string, contractAddress: string): string {
+        return `${contractAddress.toLowerCase()}_${tokenId}`;
+    }
+
+    async getMetadata(
+        tokenId: string, 
+        contractAddress: string
+    ): Promise<Omit<BaseNft, 'id' | 'contractAddress' | 'type'> | null> {
+        try {
+            await this.init();
+            if (!this.db) return null;
+
+            const cacheKey = this.getCacheKey(tokenId, contractAddress);
+            const transaction = this.db.transaction([this.storeName], 'readonly');
+            const store = transaction.objectStore(this.storeName);
+
+            return new Promise((resolve) => {
+                const request = store.get(cacheKey);
+                
+                request.onsuccess = () => {
+                    const result = request.result as CachedMetadata;
+                    if (result) {
+                        resolve(result.metadata);
+                    } else {
+                        resolve(null);
+                    }
+                };
+                
+                request.onerror = () => {
+                    console.warn('Error reading from cache:', request.error);
+                    resolve(null);
+                };
+            });
+        } catch (error) {
+            console.warn('Error accessing cache:', error);
+            return null;
+        }
+    }
+
+    async cacheMetadata(
+        tokenId: string, 
+        contractAddress: string, 
+        metadata: Omit<BaseNft, 'id' | 'contractAddress' | 'type'>
+    ): Promise<void> {
+        try {
+            await this.init();
+            if (!this.db) return;
+
+            const cacheKey = this.getCacheKey(tokenId, contractAddress);
+            const cachedData: CachedMetadata = {
+                tokenId,
+                contractAddress: contractAddress.toLowerCase(),
+                metadata,
+                timestamp: Date.now()
+            };
+
+            const transaction = this.db.transaction([this.storeName], 'readwrite');
+            const store = transaction.objectStore(this.storeName);
+
+            return new Promise((resolve, reject) => {
+                const request = store.put({ ...cachedData, cacheKey });
+                
+                request.onsuccess = () => resolve();
+                request.onerror = () => {
+                    console.warn('Error writing to cache:', request.error);
+                    reject(request.error);
+                };
+            });
+        } catch (error) {
+            console.warn('Error caching metadata:', error);
+        }
+    }
+
+    async clearCache(): Promise<void> {
+        try {
+            await this.init();
+            if (!this.db) return;
+
+            const transaction = this.db.transaction([this.storeName], 'readwrite');
+            const store = transaction.objectStore(this.storeName);
+
+            return new Promise((resolve, reject) => {
+                const request = store.clear();
+                request.onsuccess = () => resolve();
+                request.onerror = () => reject(request.error);
+            });
+        } catch (error) {
+            console.warn('Error clearing cache:', error);
+        }
+    }
+
+    async getCacheSize(): Promise<number> {
+        try {
+            await this.init();
+            if (!this.db) return 0;
+
+            const transaction = this.db.transaction([this.storeName], 'readonly');
+            const store = transaction.objectStore(this.storeName);
+
+            return new Promise((resolve) => {
+                const request = store.count();
+                request.onsuccess = () => resolve(request.result);
+                request.onerror = () => resolve(0);
+            });
+        } catch (error) {
+            console.warn('Error getting cache size:', error);
+            return 0;
+        }
+    }
+}
+
+export const nftMetadataCache = new NFTMetadataCache();


### PR DESCRIPTION
Add NFT metadata caching system and fix build error caused by missing cache files.

The build was failing with "Could not resolve ../cache/nftMetadataCache" errors because the referenced cache files were missing. This PR introduces the `src/cache/nftMetadataCache.ts` and `src/cache/cacheStrategies.ts` files, implementing an IndexedDB-based NFT metadata caching system, and updates `.gitignore` to ensure these new files are tracked.