### PR TITLE
Fix build failure due to module resolution

### DIFF
--- a/src/api/nfts.ts
+++ b/src/api/nfts.ts
@@ -3,9 +3,9 @@
 import { createPublicClient, http, type Address } from 'viem';
 import { bsc } from 'wagmi/chains';
 import { Buffer } from 'buffer';
-import { getContract, contracts, type ContractName } from '../config/contracts';
-import { nftMetadataCache } from '../cache/nftMetadataCache';
-import { CacheMetrics } from '../cache/cacheStrategies';
+import { getContract, contracts, type ContractName } from '../config/contracts.js';
+import { nftMetadataCache } from '../cache/nftMetadataCache.js';
+import { CacheMetrics } from '../cache/cacheStrategies.js';
 import type { 
     AllNftCollections, 
     BaseNft, 


### PR DESCRIPTION
Add `.js` extensions to import paths in `src/api/nfts.ts` to resolve build errors.