### PR TITLE
Add button for BSC chain switch

### DIFF
--- a/BSC_NETWORK_SWITCHING_IMPLEMENTATION.md
+++ b/BSC_NETWORK_SWITCHING_IMPLEMENTATION.md
@@ -1,0 +1,156 @@
+# BSC 網路切換功能實作文件
+
+## 問題描述
+
+您提到的問題是對的！網站確實缺少讓用戶切換到 BSC 鏈的按鈕功能。用戶可能使用 ETH 錢包連接，但由於沒有網路切換功能，導致功能無法正常運作。
+
+## 問題分析
+
+### 原始狀況：
+1. **應用程式只支援 BSC 主網**：`src/wagmi.ts` 中的設定只包含 BSC 鏈
+2. **缺少網路切換 UI**：沒有提供用戶切換網路的介面
+3. **用戶體驗差**：用戶連接錢包後，如果在錯誤的網路上，沒有明確的提示或解決方案
+
+### 根本原因：
+- 用戶可能預設連接到以太坊主網
+- 應用程式期望用戶在 BSC 主網上
+- 沒有自動檢測或提示用戶切換網路
+
+## 實作解決方案
+
+### 1. 新增網路切換元件（NetworkSwitcher）
+
+**檔案：** `src/components/ui/NetworkSwitcher.tsx`
+
+**功能：**
+- 顯示目前連接的網路狀態
+- 提供一鍵切換到 BSC 主網的功能
+- 視覺化指示器（綠色 = 正確網路，紅色 = 錯誤網路）
+- 響應式設計，適配桌面和行動裝置
+
+**主要特色：**
+```typescript
+const isOnBSC = chain?.id === bsc.id;
+const isOnWrongNetwork = isConnected && !isOnBSC;
+```
+
+### 2. 新增網路錯誤警告橫幅（WrongNetworkBanner）
+
+**檔案：** `src/components/ui/WrongNetworkBanner.tsx`
+
+**功能：**
+- 在用戶連接錯誤網路時顯示明顯的警告訊息
+- 說明當前網路和需要的網路
+- 提供直接切換按鈕
+- 自動隱藏（當用戶在正確網路上時）
+
+### 3. 新增 AlertTriangle 圖示
+
+**檔案：** `src/components/ui/icons.tsx`
+
+**新增內容：**
+- `AlertTriangleIcon` 元件
+- 整合到 `Icons` 物件中
+- 用於警告和錯誤狀態的視覺指示
+
+### 4. 整合到主要元件
+
+**更新的檔案：**
+- `src/components/layout/Header.tsx`：新增 NetworkSwitcher
+- `src/App.tsx`：新增 WrongNetworkBanner
+
+## 使用者體驗流程
+
+### 正常流程：
+1. 用戶連接錢包
+2. 如果已在 BSC 主網 → 顯示綠色狀態指示器
+3. 所有功能正常運作
+
+### 錯誤網路流程：
+1. 用戶連接錢包（但在以太坊主網）
+2. 顯示紅色狀態指示器
+3. 顯示警告橫幅，說明需要切換到 BSC
+4. 用戶點擊切換按鈕
+5. 錢包提示切換網路
+6. 切換完成後，警告消失，功能正常運作
+
+## 技術實作細節
+
+### 使用的 wagmi hooks：
+- `useAccount()`: 取得當前連接狀態和鏈資訊
+- `useSwitchChain()`: 處理網路切換功能
+
+### 網路檢測邏輯：
+```typescript
+const { chain, isConnected } = useAccount();
+const isOnBSC = chain?.id === bsc.id;
+const isOnWrongNetwork = isConnected && !isOnBSC;
+```
+
+### 切換網路邏輯：
+```typescript
+const { switchChain, isPending } = useSwitchChain();
+const handleSwitchToBSC = () => {
+  switchChain({ chainId: bsc.id });
+};
+```
+
+## 視覺設計
+
+### 網路狀態指示器：
+- ✅ **正確網路 (BSC)**：綠色背景，綠色點，顯示 "BSC 主網"
+- ❌ **錯誤網路**：紅色背景，紅色點，顯示實際網路名稱 + 警告圖示
+
+### 警告橫幅：
+- 紅色邊框和背景
+- 警告三角形圖示
+- 清楚的說明文字
+- 顯著的切換按鈕
+
+## 測試建議
+
+### 測試場景：
+1. **正確網路連接**：
+   - 錢包已設定 BSC 主網
+   - 連接後應顯示綠色狀態
+   - 不應顯示警告橫幅
+
+2. **錯誤網路連接**：
+   - 錢包設定為以太坊主網
+   - 連接後應顯示紅色狀態
+   - 應顯示警告橫幅
+   - 點擊切換按鈕應觸發錢包切換網路
+
+3. **網路切換後**：
+   - 切換完成後狀態應更新
+   - 警告橫幅應消失
+   - 應用程式功能應正常運作
+
+## 後續建議
+
+### 可能的改進：
+1. **自動切換提示**：第一次連接時如果在錯誤網路，自動彈出切換提示
+2. **網路歷史記錄**：記住用戶的網路偏好
+3. **多鏈支援**：如果未來需要支援其他鏈，可以擴展這個架構
+4. **錯誤處理**：處理網路切換失敗的情況
+
+### 維護注意事項：
+- 確保 BSC 鏈 ID 正確（目前使用 `bsc.id` 從 wagmi/chains）
+- 監控 RPC 節點的可用性
+- 定期檢查網路切換功能是否正常
+
+## 檔案變更摘要
+
+```
+新增檔案：
+├── src/components/ui/NetworkSwitcher.tsx
+├── src/components/ui/WrongNetworkBanner.tsx
+└── BSC_NETWORK_SWITCHING_IMPLEMENTATION.md
+
+修改檔案：
+├── src/components/ui/icons.tsx (新增 AlertTriangle 圖示)
+├── src/components/layout/Header.tsx (整合 NetworkSwitcher)
+└── src/App.tsx (整合 WrongNetworkBanner)
+```
+
+這個實作完全解決了您提到的問題：用戶現在可以清楚地看到網路狀態，並且有明確的方式切換到 BSC 主網！

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { LoadingSpinner } from './components/ui/LoadingSpinner';
 import type { Page } from './types/page';
 import { TransactionWatcher } from './components/core/TransactionWatcher';
 import ErrorBoundary from './components/common/ErrorBoundary';
+import { WrongNetworkBanner } from './components/ui/WrongNetworkBanner';
 
 // 動態導入所有頁面
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
@@ -94,6 +95,7 @@ function App() {
     <ErrorBoundary>
       <div className="min-h-screen flex flex-col dark:bg-gray-900 bg-gray-100">
         <Header activePage={activePage} setActivePage={handleSetPage} />
+        <WrongNetworkBanner />
         <main className="flex-grow container mx-auto px-4 py-8 md:px-6 md:py-12">
             <Suspense fallback={<PageLoader />}>
                 {renderPage()}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,6 +12,7 @@ import { getContract } from '../../config/contracts';
 import { RecentTransactions } from '../ui/RecentTransactions';
 import { Icons } from '../ui/icons';
 import { bsc } from 'wagmi/chains';
+import { NetworkSwitcher } from '../ui/NetworkSwitcher';
 
 // (此處省略未變更的 ThemeToggleButton, MenuIcon, XIcon 元件程式碼)
 const ThemeToggleButton: React.FC = () => {
@@ -150,6 +151,7 @@ export const Header: React.FC<{ activePage: Page; setActivePage: (page: Page) =>
                 
                 <div className="flex items-center gap-1 md:gap-2">
                     <ThemeToggleButton />
+                    <NetworkSwitcher />
                     {isConnected && (
                       <div className="relative" ref={popoverRef}>
                         <button onClick={() => setIsTxPopoverOpen(prev => !prev)} className="p-2 rounded-full text-gray-300 hover:bg-white/20 transition-colors" aria-label="顯示最近交易">

--- a/src/components/ui/NetworkSwitcher.tsx
+++ b/src/components/ui/NetworkSwitcher.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { useAccount, useSwitchChain } from 'wagmi';
+import { bsc } from 'wagmi/chains';
+import { ActionButton } from './ActionButton';
+import { Icons } from './icons';
+
+export const NetworkSwitcher: React.FC = () => {
+  const { chain, isConnected } = useAccount();
+  const { switchChain, isPending } = useSwitchChain();
+  const [isHovered, setIsHovered] = useState(false);
+
+  const isOnBSC = chain?.id === bsc.id;
+  const isOnWrongNetwork = isConnected && !isOnBSC;
+
+  const handleSwitchToBSC = () => {
+    switchChain({ chainId: bsc.id });
+  };
+
+  if (!isConnected) {
+    return null;
+  }
+
+  return (
+    <div className="relative">
+      {/* 網路狀態指示器 */}
+      <div 
+        className={`flex items-center gap-2 px-3 py-2 rounded-full text-sm font-medium cursor-pointer transition-all ${
+          isOnBSC 
+            ? 'bg-green-500/20 text-green-400 border border-green-500/50' 
+            : 'bg-red-500/20 text-red-400 border border-red-500/50 hover:bg-red-500/30'
+        }`}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onClick={isOnWrongNetwork ? handleSwitchToBSC : undefined}
+      >
+        <div className={`w-2 h-2 rounded-full ${isOnBSC ? 'bg-green-400' : 'bg-red-400'}`} />
+        <span className="hidden sm:inline">
+          {isOnBSC ? 'BSC 主網' : chain?.name || '未知網路'}
+        </span>
+        {isOnWrongNetwork && (
+          <Icons.AlertTriangle className="w-4 h-4" />
+        )}
+      </div>
+
+      {/* 錯誤網路提示 */}
+      {isOnWrongNetwork && (
+        <div className="absolute top-full mt-2 right-0 bg-red-500/90 text-white text-xs px-3 py-2 rounded-lg shadow-lg z-50 whitespace-nowrap">
+          <div className="flex items-center gap-2">
+            <Icons.AlertTriangle className="w-3 h-3" />
+            <span>請切換至 BSC 主網</span>
+          </div>
+          <div className="mt-2">
+            <ActionButton
+              onClick={handleSwitchToBSC}
+              isLoading={isPending}
+              disabled={isPending}
+              className="bg-white/20 hover:bg-white/30 text-white text-xs px-2 py-1 rounded"
+            >
+              {isPending ? '切換中...' : '切換到 BSC'}
+            </ActionButton>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NetworkSwitcher;

--- a/src/components/ui/WrongNetworkBanner.tsx
+++ b/src/components/ui/WrongNetworkBanner.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useAccount, useSwitchChain } from 'wagmi';
+import { bsc } from 'wagmi/chains';
+import { ActionButton } from './ActionButton';
+import { Icons } from './icons';
+
+export const WrongNetworkBanner: React.FC = () => {
+  const { chain, isConnected } = useAccount();
+  const { switchChain, isPending } = useSwitchChain();
+
+  const isOnBSC = chain?.id === bsc.id;
+  const isOnWrongNetwork = isConnected && !isOnBSC;
+
+  if (!isOnWrongNetwork) {
+    return null;
+  }
+
+  const handleSwitchToBSC = () => {
+    switchChain({ chainId: bsc.id });
+  };
+
+  return (
+    <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 mx-4 mt-4 flex items-center justify-between">
+      <div className="flex items-center gap-3">
+        <Icons.AlertTriangle className="w-6 h-6 text-red-400" />
+        <div>
+          <h3 className="text-red-400 font-medium">網路不正確</h3>
+          <p className="text-red-300 text-sm">
+            您目前連接到 {chain?.name || '未知網路'}，但此應用程式需要使用 BSC 主網。
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <ActionButton
+          onClick={handleSwitchToBSC}
+          isLoading={isPending}
+          disabled={isPending}
+          className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg text-sm"
+        >
+          {isPending ? '切換中...' : '切換到 BSC 主網'}
+        </ActionButton>
+      </div>
+    </div>
+  );
+};
+
+export default WrongNetworkBanner;

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -33,6 +33,15 @@ const CopyIcon: React.FC<{ className?: string }> = ({ className }) => (
     </svg>
 );
 
+// ★ 新增：警告三角形圖示
+const AlertTriangleIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+        <line x1="12" y1="9" x2="12" y2="13"></line>
+        <line x1="12" y1="17" x2="12.01" y2="17"></line>
+    </svg>
+);
+
 
 const HeroIcon: React.FC<{ className?: string }> = ({ className }) => <span className={className}>🦸</span>;
 const RelicIcon: React.FC<{ className?: string }> = ({ className }) => <span className={className}>💎</span>;
@@ -60,4 +69,5 @@ export const Icons = {
     Codex: CodexIcon,
     Twitter: TwitterIcon, // ★ 新增
     Copy: CopyIcon,       // ★ 新增
+    AlertTriangle: AlertTriangleIcon, // ★ 新增：警告三角形圖示
 };


### PR DESCRIPTION
Implement BSC network switching UI and logic to guide users to the correct chain.

The application was configured to only support the BSC mainnet, but there was no user interface for network switching. This led to a poor user experience where users connecting from other networks (e.g., Ethereum) would find the application non-functional without clear guidance. This PR adds a network status indicator and a warning banner with a one-click switch button.