### PR TITLE
Fix indexing error for missing createdAt

### DIFF
--- a/DDgraphql/dungeon-delvers/src/relic.ts
+++ b/DDgraphql/dungeon-delvers/src/relic.ts
@@ -15,6 +15,7 @@ export function handleRelicMinted(event: RelicMinted): void {
     relic.contractAddress = event.address
     relic.rarity = event.params.rarity
     relic.capacity = event.params.capacity
+    relic.createdAt = event.block.timestamp
     relic.save()
 }
 


### PR DESCRIPTION
Set `createdAt` field for `Relic` entity to fix subgraph indexing error.