### PR TITLE
Check front-end API format updates

### DIFF
--- a/API_ROUTE_STATUS_REPORT.md
+++ b/API_ROUTE_STATUS_REPORT.md
@@ -9,8 +9,8 @@
 - `/api/hero/:tokenId` ✅
 - `/api/relic/:tokenId` ✅
 - `/api/party/:tokenId` ✅
-- `/api/playerprofile/:tokenId` ✅ (已從 `/api/profile` 改為此)
-- `/api/vipstaking/:tokenId` ✅ (已從 `/api/vip` 改為此)
+- `/api/profile/:tokenId` ✅ (最終正確版本)
+- `/api/vip/:tokenId` ✅ (最終正確版本)
 
 ### ✅ 前端程式碼 (無需修改)
 **檢查範圍**: `src/`, `public/`, `components/`, `pages/` 等所有前端目錄
@@ -24,17 +24,22 @@
 
 ### ✅ 測試腳本 (已正確)
 **檔案**: `diagnostic_script.js`
-- 使用正確的 `/api/vipstaking` 端點 ✅
+- 使用正確的 `/api/vip` 端點 ✅
 
 ### ✅ 文件已修正
 **已修正的檔案**:
 1. `dungeon-delvers-metadata-server/README.md` ✅
-   - 從 `/api/profile` → `/api/playerprofile`
-   - 從 `/api/vip` → `/api/vipstaking`
+   - 使用正確的 `/api/profile` 和 `/api/vip` 端點
 
 2. `dungeon-delvers-metadata-server/DEPLOYMENT_GUIDE.md` ✅
-   - 新增正確的 API 端點說明
+   - 使用正確的 API 端點說明
    - 更新測試命令
+
+3. `dungeon-delvers-metadata-server/scripts/test-performance.sh` ✅
+   - 更新測試端點
+
+4. `diagnostic_script.js` ✅
+   - 更新 VIP API 測試端點
 
 ## 🔍 最終確認
 
@@ -43,8 +48,8 @@
 GET /api/hero/:tokenId
 GET /api/relic/:tokenId  
 GET /api/party/:tokenId
-GET /api/playerprofile/:tokenId  (不是 /api/profile)
-GET /api/vipstaking/:tokenId     (不是 /api/vip)
+GET /api/profile/:tokenId    (個人檔案)
+GET /api/vip/:tokenId        (VIP 卡)
 ```
 
 ### 檢查結果
@@ -61,8 +66,8 @@ GET /api/vipstaking/:tokenId     (不是 /api/vip)
 
 ## 🎯 結論
 
-**所有 API 路由問題已解決**，目前系統使用統一的端點格式：
-- 個人檔案: `/api/playerprofile/:tokenId`
-- VIP 卡: `/api/vipstaking/:tokenId`
+**所有 API 路由問題已解決**，目前系統使用簡潔的端點格式：
+- 個人檔案: `/api/profile/:tokenId`
+- VIP 卡: `/api/vip/:tokenId`
 
 前端程式碼無需修改，因為它透過 The Graph 和直接合約呼叫來獲取資料。

--- a/API_ROUTE_STATUS_REPORT.md
+++ b/API_ROUTE_STATUS_REPORT.md
@@ -1,0 +1,68 @@
+# API 路由狀態報告
+
+## 📋 當前狀況
+
+### ✅ 後端伺服器 (已正確)
+**檔案**: `dungeon-delvers-metadata-server/src/index.js`
+
+實際運行的 API 路由：
+- `/api/hero/:tokenId` ✅
+- `/api/relic/:tokenId` ✅
+- `/api/party/:tokenId` ✅
+- `/api/playerprofile/:tokenId` ✅ (已從 `/api/profile` 改為此)
+- `/api/vipstaking/:tokenId` ✅ (已從 `/api/vip` 改為此)
+
+### ✅ 前端程式碼 (無需修改)
+**檢查範圍**: `src/`, `public/`, `components/`, `pages/` 等所有前端目錄
+
+**結果**: 前端程式碼並未直接呼叫這些 API 端點，而是透過：
+1. **The Graph (GraphQL)** 查詢玩家資料
+2. **直接呼叫合約** 的 `tokenURI` 函數取得 metadata
+3. **fetchMetadata 函數** 處理 IPFS/HTTP 內容
+
+因此前端無需修改。
+
+### ✅ 測試腳本 (已正確)
+**檔案**: `diagnostic_script.js`
+- 使用正確的 `/api/vipstaking` 端點 ✅
+
+### ✅ 文件已修正
+**已修正的檔案**:
+1. `dungeon-delvers-metadata-server/README.md` ✅
+   - 從 `/api/profile` → `/api/playerprofile`
+   - 從 `/api/vip` → `/api/vipstaking`
+
+2. `dungeon-delvers-metadata-server/DEPLOYMENT_GUIDE.md` ✅
+   - 新增正確的 API 端點說明
+   - 更新測試命令
+
+## 🔍 最終確認
+
+### 目前使用的 API 端點
+```
+GET /api/hero/:tokenId
+GET /api/relic/:tokenId  
+GET /api/party/:tokenId
+GET /api/playerprofile/:tokenId  (不是 /api/profile)
+GET /api/vipstaking/:tokenId     (不是 /api/vip)
+```
+
+### 檢查結果
+- ✅ 後端程式碼使用正確路由
+- ✅ 前端程式碼無直接呼叫，無需修改
+- ✅ 測試腳本使用正確端點
+- ✅ 文件已更新為正確資訊
+
+## 💡 建議
+
+1. **合約層面**: 確認智能合約的 `tokenURI` 函數返回正確的 URL
+2. **快取清理**: 如果之前部署過舊端點，建議清理 CDN/瀏覽器快取
+3. **監控**: 使用 `/health` 端點監控服務狀態
+
+## 🎯 結論
+
+**所有 API 路由問題已解決**，目前系統使用統一的端點格式：
+- 個人檔案: `/api/playerprofile/:tokenId`
+- VIP 卡: `/api/vipstaking/:tokenId`
+
+前端程式碼無需修改，因為它透過 The Graph 和直接合約呼叫來獲取資料。

--- a/diagnostic_script.js
+++ b/diagnostic_script.js
@@ -187,7 +187,7 @@ async function checkMetadataServer() {
     }
     
     // 測試 VIP NFT API
-    const vipApiResponse = await fetch(`${config.metadataServerUrl}/api/vipstaking/${config.testTokenIds.vip}`, {
+    const vipApiResponse = await fetch(`${config.metadataServerUrl}/api/vip/${config.testTokenIds.vip}`, {
       timeout: 10000,
     });
     

--- a/dungeon-delvers-metadata-server/DEPLOYMENT_GUIDE.md
+++ b/dungeon-delvers-metadata-server/DEPLOYMENT_GUIDE.md
@@ -92,8 +92,8 @@ curl http://localhost/health
 
 # 測試 API 端點
 curl http://localhost/api/hero/1
-curl http://localhost/api/playerprofile/1
-curl http://localhost/api/vipstaking/1
+curl http://localhost/api/profile/1
+curl http://localhost/api/vip/1
 
 # 檢查快取統計
 curl http://localhost/admin/cache/stats
@@ -112,8 +112,8 @@ curl http://localhost/admin/metrics
 | `/api/hero/:id` | 英雄元數據 | `GET /api/hero/1` |
 | `/api/relic/:id` | 遺物元數據 | `GET /api/relic/1` |
 | `/api/party/:id` | 隊伍元數據 | `GET /api/party/1` |
-| `/api/playerprofile/:id` | 玩家檔案元數據 | `GET /api/playerprofile/1` |
-| `/api/vipstaking/:id` | VIP 卡元數據 | `GET /api/vipstaking/1` |
+| `/api/profile/:id` | 玩家檔案元數據 | `GET /api/profile/1` |
+| `/api/vip/:id` | VIP 卡元數據 | `GET /api/vip/1` |
 | `/admin/cache/stats` | 快取統計 | `GET /admin/cache/stats` |
 | `/admin/cache/clear` | 清除快取 | `POST /admin/cache/clear` |
 | `/admin/metrics` | 性能指標 | `GET /admin/metrics` |

--- a/dungeon-delvers-metadata-server/DEPLOYMENT_GUIDE.md
+++ b/dungeon-delvers-metadata-server/DEPLOYMENT_GUIDE.md
@@ -92,6 +92,8 @@ curl http://localhost/health
 
 # 測試 API 端點
 curl http://localhost/api/hero/1
+curl http://localhost/api/playerprofile/1
+curl http://localhost/api/vipstaking/1
 
 # 檢查快取統計
 curl http://localhost/admin/cache/stats
@@ -110,6 +112,8 @@ curl http://localhost/admin/metrics
 | `/api/hero/:id` | 英雄元數據 | `GET /api/hero/1` |
 | `/api/relic/:id` | 遺物元數據 | `GET /api/relic/1` |
 | `/api/party/:id` | 隊伍元數據 | `GET /api/party/1` |
+| `/api/playerprofile/:id` | 玩家檔案元數據 | `GET /api/playerprofile/1` |
+| `/api/vipstaking/:id` | VIP 卡元數據 | `GET /api/vipstaking/1` |
 | `/admin/cache/stats` | 快取統計 | `GET /admin/cache/stats` |
 | `/admin/cache/clear` | 清除快取 | `POST /admin/cache/clear` |
 | `/admin/metrics` | 性能指標 | `GET /admin/metrics` |

--- a/dungeon-delvers-metadata-server/README.md
+++ b/dungeon-delvers-metadata-server/README.md
@@ -5,7 +5,7 @@
 ## 專案目的
 
 當 NFT 在 OpenSea、錢包或其他第三方平台顯示時，這些平台會呼叫 NFT 合約的 `tokenURI` 函式來獲取元數據。為了讓 NFT 的圖片能夠即時反映鏈上的最新狀態（例如玩家等級、VIP 等級等），我們需要一個能夠：
-1.  接收 API 請求 (例如 `/api/profile/123`)。
+1.  接收 API 請求 (例如 `/api/playerprofile/123`)。
 2.  即時讀取區塊鏈上的數據。
 3.  根據最新數據動態生成 SVG 圖像。
 4.  將包含 SVG 的元數據 JSON 回傳。
@@ -52,5 +52,5 @@
 -   `GET /api/hero/:tokenId`
 -   `GET /api/relic/:tokenId`
 -   `GET /api/party/:tokenId`
--   `GET /api/profile/:tokenId`
--   `GET /api/vip/:tokenId`
+-   `GET /api/playerprofile/:tokenId`
+-   `GET /api/vipstaking/:tokenId`

--- a/dungeon-delvers-metadata-server/README.md
+++ b/dungeon-delvers-metadata-server/README.md
@@ -5,7 +5,7 @@
 ## 專案目的
 
 當 NFT 在 OpenSea、錢包或其他第三方平台顯示時，這些平台會呼叫 NFT 合約的 `tokenURI` 函式來獲取元數據。為了讓 NFT 的圖片能夠即時反映鏈上的最新狀態（例如玩家等級、VIP 等級等），我們需要一個能夠：
-1.  接收 API 請求 (例如 `/api/playerprofile/123`)。
+1.  接收 API 請求 (例如 `/api/profile/123`)。
 2.  即時讀取區塊鏈上的數據。
 3.  根據最新數據動態生成 SVG 圖像。
 4.  將包含 SVG 的元數據 JSON 回傳。
@@ -52,5 +52,5 @@
 -   `GET /api/hero/:tokenId`
 -   `GET /api/relic/:tokenId`
 -   `GET /api/party/:tokenId`
--   `GET /api/playerprofile/:tokenId`
--   `GET /api/vipstaking/:tokenId`
+-   `GET /api/profile/:tokenId`
+-   `GET /api/vip/:tokenId`

--- a/dungeon-delvers-metadata-server/scripts/test-performance.sh
+++ b/dungeon-delvers-metadata-server/scripts/test-performance.sh
@@ -25,8 +25,8 @@ endpoints=(
     "/api/hero/1"
     "/api/relic/1"
     "/api/party/1"
-    "/api/playerprofile/1"
-    "/api/vipstaking/1"
+    "/api/profile/1"
+"/api/vip/1"
 )
 
 echo "🔍 Testing endpoints..."

--- a/dungeon-delvers-metadata-server/src/index.js
+++ b/dungeon-delvers-metadata-server/src/index.js
@@ -205,8 +205,8 @@ app.get('/api/party/:tokenId', handleRequest(async (req, res) => {
 
 // --- Profile 和 VIP 端點 (已修正路由) ---
 
-// ★ 核心修正：將路由從 /api/profile/ 改為 /api/playerprofile/
-app.get('/api/playerprofile/:tokenId', handleRequest(async (req, res) => {
+// ★ 核心修正：將路由改為 /api/profile/
+app.get('/api/profile/:tokenId', handleRequest(async (req, res) => {
     const { tokenId } = req.params;
     const cacheKey = `profile-${tokenId}`;
 
@@ -242,8 +242,8 @@ app.get('/api/playerprofile/:tokenId', handleRequest(async (req, res) => {
     res.json(metadata);
 }));
 
-// ★ 核心修正：將路由從 /api/vip/ 改為 /api/vipstaking/
-app.get('/api/vipstaking/:tokenId', handleRequest(async (req, res) => {
+// ★ 核心修正：將路由改為 /api/vip/
+app.get('/api/vip/:tokenId', handleRequest(async (req, res) => {
     const { tokenId } = req.params;
     const cacheKey = `vip-${tokenId}`;
 


### PR DESCRIPTION
Standardize API endpoints for player profile and VIP card to `/api/profile` and `/api/vip`.

The user clarified that the intended final API routes were `/api/profile` and `/api/vip`, not the previously assumed `/api/playerprofile` and `/api/vipstaking`. This PR corrects the backend routes, documentation, and test scripts to align with the confirmed short-form endpoints. The frontend remains unaffected as it fetches metadata via smart contract `tokenURI` calls.