### PR TITLE
Fix unknown at rules in CSS

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": ["stylelint-config-standard"],
+  "plugins": ["stylelint-order"],
+  "rules": {
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+          "tailwind",
+          "apply",
+          "variants",
+          "responsive",
+          "screen",
+          "layer"
+        ]
+      }
+    ],
+    "declaration-block-trailing-semicolon": null,
+    "no-descending-specificity": null,
+    "order/properties-alphabetical-order": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
+    "lint:css": "stylelint \"src/**/*.css\"",
     "preview": "vite preview",
     "check-consistency": "node consistency-check.js"
   },
@@ -37,6 +38,9 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "postcss": "^8.5.6",
     "rollup-plugin-visualizer": "^6.0.3",
+    "stylelint": "^16.10.0",
+    "stylelint-config-standard": "^36.0.1",
+    "stylelint-order": "^6.0.4",
     "tailwindcss": "^3.4.17",
     "terser": "^5.43.1",
     "typescript": "^5.2.2",


### PR DESCRIPTION
Add Stylelint configuration and dependencies to resolve Tailwind CSS `@tailwind` and `@apply` linting errors.

The default CSS linter does not recognize Tailwind CSS at-rules, leading to "unknown at rule" errors. This PR introduces Stylelint with a configuration that ignores these specific Tailwind directives, allowing for proper CSS linting while supporting Tailwind's syntax.